### PR TITLE
Prevent sign_flip from overflowing in the Chebyshev grid calculation

### DIFF
--- a/python/sparse_grid/repn/chebyshev.py
+++ b/python/sparse_grid/repn/chebyshev.py
@@ -101,7 +101,7 @@ def eval_Imz(poly, stat, n, prec):
 def _sign_changes(fn):
     "Given a discretized 1D function, return the location of the extrema"
     fn = np.asarray(fn)
-    sign_flip = fn[1:] * fn[:-1] < 0
+    sign_flip = ((fn[1:] < 0) & (fn[:-1] > 0)) | ((fn[1:] > 0) & (fn[:-1] < 0))
     return sign_flip.nonzero()[0]
 
 


### PR DESCRIPTION
When the user-requested number of coefficients is large, the precision type cannot hold the result of the product without overflowing. This change fixes the warning and prevent an overflow.