### PR TITLE
using CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR so cmake f…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ else ()
     set(GIT_HASH "${GIT_HASH}**${PROJECT_NAME}:${TMP_HASH}" CACHE INTERNAL "")
 endif ()
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(GreenDeps)
 


### PR DESCRIPTION
…iles are found if grids are used as a dependency